### PR TITLE
Keep index dir

### DIFF
--- a/lib/file_handling.ex
+++ b/lib/file_handling.ex
@@ -1,7 +1,7 @@
 defmodule FileHandling do
   @file_name "wsj"
   def make_file_input_string(type) do
-    "./indexs/#{file_name()}_#{type}.out"
+    "./indexes/#{file_name()}_#{type}.out"
   end
 
   def file_name, do: @file_name


### PR DESCRIPTION
Keeps the index dir in the git repo so that it doesn't fail writing the index at runtime