### PR TITLE
Simplify search_engine main

### DIFF
--- a/lib/search_engine.ex
+++ b/lib/search_engine.ex
@@ -3,13 +3,12 @@ defmodule SearchEngine do
   import Serialization
 
   def main(_) do
-    input =
-      IO.read(:stdio, :all)
-      |> String.split(" ")
-      |> Enum.map(&String.downcase/1)
-      |> Enum.map(&String.trim/1)
-
-    search(input)
+    Enum.each(IO.stream(), fn line ->
+      line
+      |> String.downcase
+      |> String.split
+      |> search
+    end)
   end
 
   def get_posting(word, dict, lengths, file_pid) do


### PR DESCRIPTION
Simplifies the definition of main in the search_engine. The intent is to allow interactive search sessions with one query per line. I believe this doesn't violate the assignment spec but you'd have to check for me